### PR TITLE
Set body only for supported request types

### DIFF
--- a/src/classes/HttpClient.cls
+++ b/src/classes/HttpClient.cls
@@ -37,8 +37,10 @@ public with sharing class HttpClient {
         HttpRequest request = new HttpRequest();
         request.setEndpoint(endpoint);
         request.setMethod(method);
-        request.setHeader('Content-Type', 'application/json;charset=UTF-8');
-        request.setBody(payload);
+        if(new String[]{'POST', 'PATCH', 'PUT'}.contains( method )){
+            request.setHeader('Content-Type', 'application/json;charset=UTF-8');
+            request.setBody(payload);
+        }
 
         if(credentials != null) {
             if(credentials instanceof NamedCredentialsProvider) {


### PR DESCRIPTION
request.setBody('') automatically turns get requests into POST
setting content type on blank body doesn't make sense either